### PR TITLE
Parametrize user options

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -69,9 +69,12 @@ def parse_args():
     parser.add_argument("-I", "--intervals-to-wait", metavar="<int>", type=int,
             default=3, help="Number of --run-duration intervals to wait for run to be " +
             "complete. (default %(default)s)")
-    parser.add_argument("-u", "--upload-thumbnails", action="store_true",
+    parser.add_argument("-U", "--upload-thumbnails", action="store_true",
             help="Flag to specify uploaded thumbnail (JPEG) files as well " +
             "as BCL files")
+    parser.add_argument("-u", "--upload-threads", metavar="<int>", type=int,
+            default=8, help="Number of upload threads in Upload Agent " +
+            "(decrease down to 1 for low bandwidth connections, default %(default)s)")
     parser.add_argument("-R", "--retries", metavar="<int>", type=int, default=3,
             help="Number of times the script will attempt to tar and upload " +
             "a set of files before failing.")
@@ -265,6 +268,7 @@ def run_sync_dir(lane, args, finish=False):
     invocation.extend(exclude_patterns)
     invocation.extend(["--min-tar-size", str(args.min_size)])
     invocation.extend(["--max-tar-size", str(args.max_size)])
+    invocation.extend(["--upload-threads", str(args.upload_threads)])
     invocation.extend(["--prefix", lane["prefix"]])
     if args.verbose:
         invocation.append("--verbose")

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -28,7 +28,8 @@ CONFIG_DEFAULT = {
     "min_interval": 1800,
     "n_retries": 3,
     "run_length": "24h",
-    "n_seq_intervals": 2
+    "n_seq_intervals": 2,
+    "n_upload_threads": 8
 }
 
 # Base folder in which the RUN folders are deposited
@@ -334,6 +335,7 @@ def _trigger_streaming_upload(folder, config):
                "-R", config['n_retries'],
                "-D", config['run_length'],
                "-I", config['n_seq_intervals'],
+               "-u", config['n_upload_threads']
                "--verbose"]
 
     if 'applet' in config:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,6 +104,20 @@
   become_user: "{{ item.username }}"
   when: item.n_seq_intervals is defined
 
+- name: Change number of retries for incremental_upload
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_retries:.*' line='n_retries: \'{{ item.n_retries }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.n_retries is defined
+
+- name: Change number of upload threads for UA
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_upload_threads:.*' line='n_upload_threads: \'{{ item.n_upload_threads }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.n_upload_threads is defined
+
 # Create lock file
 - name: Create lock file for CRON to wait on using flock
   file: path=/var/lock/dnanexus_uploader.lock state=touch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,6 +118,13 @@
   become_user: "{{ item.username }}"
   when: item.n_upload_threads is defined
 
+- name: Change specification for downstream input
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^downstream_input:.*' line='downstream_input: \'{{ item.downstream_input }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.downstream_input is defined
+
 # Create lock file
 - name: Create lock file for CRON to wait on using flock
   file: path=/var/lock/dnanexus_uploader.lock state=touch

--- a/templates/monitor_run_config.template
+++ b/templates/monitor_run_config.template
@@ -21,3 +21,10 @@ run_length: 24h
 # and the program will not attempt to upload it
 # Correspond to the -I parameter in incremental upload
 n_seq_intervals: 2
+
+# Number of upload threads executed by Upload Agent (UA)
+# This number should be reduced (to as low as 1) for upload
+# sites with low upload bandwidth to increase chance
+# of successful uploads in spite of network disruptions
+# Corresponds to the -u option in UA and incremental_upload.py
+n_upload_threads: 8

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,6 +8,7 @@
           - ~/runs
         run_length: 24h
         n_seq_intervals: 2
+        n_retries: 5
       - username: root
         monitored_directories:
           - ~/home/root/runs


### PR DESCRIPTION
Addressing #6 #7 #9 
### Summary

Parametrize the following as user specified Ansible variables:
- Number of retries in `incremental_upload.py`
- Number of upload threads triggered by `Upload Agent`
- Input/options for downstream DNAnexus applet/workflow triggered post `incremental upload`
### TODO
- Update README and code example
