### PR TITLE
expose min_size, min_interval, and n_streaming_threads via ansible config

### DIFF
--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -31,7 +31,8 @@ CONFIG_DEFAULT = {
     "run_length": "24h",
     "n_seq_intervals": 2,
     "n_upload_threads": 8,
-    "downstream_input": ''
+    "downstream_input": '',
+    "n_streaming_threads":1
 }
 
 # Base folder in which the RUN folders are deposited
@@ -46,11 +47,6 @@ RUN_UPLOAD_DEST = "/"
 # Name of the sub-folder that corresponds to where the
 # run directory tarballs and upload sentinel file are stored
 REMOTE_RUN_FOLDER = "runs"
-
-# Number of incremental_upload threads to execute concurrently
-# It is not recommended to open too many upload thread, since each
-# upload is already optimized to maximize upload bandwidth
-N_STREAMING_THREADS = 1
 
 def parse_args():
     """ Parse command line arguments """
@@ -374,7 +370,7 @@ def _trigger_streaming_upload(folder, config):
 def trigger_streaming_upload(folders, config):
     """ Open a thread pool of size N_STREAMING_THREADS
     and trigger streaming upload for all unsynced and incomplete folders"""
-    pool = multiprocessing.Pool(processes=N_STREAMING_THREADS)
+    pool = multiprocessing.Pool(processes=config["n_streaming_threads"])
     for folder in folders:
         print "Adding folder {0} to pool".format(folder)
         pool.apply_async(_trigger_streaming_upload, args=(folder, config)).get()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,6 +125,27 @@
   become_user: "{{ item.username }}"
   when: item.downstream_input is defined
 
+- name: Change specification for minimum upload size
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_size:.*' line='min_size: \'{{ item.min_size }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.min_size is defined
+
+- name: Change specification for minimum sync interval
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_interval:.*' line='min_interval: \'{{ item.min_interval }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.min_interval is defined
+
+- name: Change specification for number of concurrent uploads
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_streaming_threads:.*' line='n_streaming_threads: \'{{ item.n_streaming_threads }}\''"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.n_streaming_threads is defined
+
 # Create lock file
 - name: Create lock file for CRON to wait on using flock
   file: path=/var/lock/dnanexus_uploader.lock state=touch

--- a/templates/monitor_run_config.template
+++ b/templates/monitor_run_config.template
@@ -28,3 +28,12 @@ n_seq_intervals: 2
 # of successful uploads in spite of network disruptions
 # Corresponds to the -u option in UA and incremental_upload.py
 n_upload_threads: 8
+
+# the minimum size needed to upload a chunk (in MB)
+min_size: 500
+
+# min sync check interval (in seconds)
+min_interval: 900
+
+# number of concurrent uploads
+n_streaming_threads: 1


### PR DESCRIPTION
expose `min_size`, `min_interval`, and `n_streaming_threads` as values that can be set via Ansible config. Additionally, allow `n_streaming_threads` to be set by the dx upload config file rather than relying on a hard-coded constant in `monitor_runs.py`. The latter change is to support parallel uploads, which is useful if the uploader is waiting for a failed/terminated run to time out, which can prevent newer runs from being uploaded prior to the timeout elapsing.