### PR TITLE
allow incremental_upload.py to accept json values for downstream inputs

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -435,8 +435,8 @@ def main():
 
         for k, v in input_dict.items():
             if not ((isinstance(k, str) or isinstance(k, basestring)) and
-                    (isinstance(v, str) or isinstance(v, basestring))):
-                    raise_error("Expected string key value pairs for downstream input. Got %s %s" %(k, v))
+                    (isinstance(v, str) or isinstance(v, basestring) or isinstance(v, dict))):
+                    raise_error("Expected (string) key and (string or dict) value pairs for downstream input. Got (%s)%s (%s)%s" %(type(k), k, type(v), v))
 
             downstream_input[k] = v
 


### PR DESCRIPTION
allow incremental_upload.py to accept json values for downstream inputs; this is necessary to pass $dnanexus_links as an input values