### PR TITLE
update YAML escape for newer Ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ addons:
 
 install:
   # Install ansible
-  # TODO: un-pin ansible version once https://github.com/ansible/ansible-modules-core/commit/531e09ce167c44387fc9c6505dd0453a7251b8f9 is available via pip
-  - pip install ansible==2.1.1
+  - pip install ansible==2.6.2
 
   # Check ansible version
   - ansible --version

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -370,7 +370,7 @@ def _trigger_streaming_upload(folder, config):
 def trigger_streaming_upload(folders, config):
     """ Open a thread pool of size N_STREAMING_THREADS
     and trigger streaming upload for all unsynced and incomplete folders"""
-    pool = multiprocessing.Pool(processes=config["n_streaming_threads"])
+    pool = multiprocessing.Pool(processes=int(config["n_streaming_threads"]))
     for folder in folders:
         print "Adding folder {0} to pool".format(folder)
         pool.apply_async(_trigger_streaming_upload, args=(folder, config)).get()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -190,12 +190,11 @@
 
 
 - name: set up CRON job to run every hour in deploy mode with downstream applet
-  cron:
-    name: "DNAnexus monitor runs (deploy)"
-    special_time: hourly
-    user: "{{ item.0.username }}"
-    job: >
-      "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+  cron: >
+    name="DNAnexus monitor runs (deploy)"
+    special_time=hourly
+    user="{{ item.0.username }}"
+    job="flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories
@@ -205,10 +204,10 @@
 
 # Clean up CRON job in alternate mode
 - name: delete deploy mode CRON job if debug mode set
-  cron:
-    name: "DNAnexus monitor runs (deploy)"
-    user: "{{ item.username }}"
-    state: absent
+  cron: >
+    name="DNAnexus monitor runs (deploy)"
+    user="{{ item.username }}"
+    state=absent
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
@@ -216,10 +215,10 @@
 
 
 - name: delete debug mode CRON job if deploy mode set
-  cron:
-    name: "DNAnexus monitor runs (debug)"
-    user: "{{ item.username }}"
-    state: absent
+  cron: >
+    name="DNAnexus monitor runs (debug)"
+    user="{{ item.username }}"
+    state=absent
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 # Install Dx-toolkit
 - name: Get DX tarball
-  unarchive: src=https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-14.04-amd64.tar.gz remote_src=yes dest=/opt/
+  unarchive: 
+    src: https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-14.04-amd64.tar.gz 
+    remote_src: yes 
+    dest: /opt/
 
 # http://stackoverflow.com/questions/22256884/not-possible-to-source-bashrc-with-ansible
 - name: check dx version
@@ -19,7 +22,10 @@
   file: path=/opt/dnanexus-upload-agent state=directory mode=0755
 
 - name: Download and unzip UA tarball
-  unarchive: src=https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-1.5.10-linux.tar.gz dest=/opt/dnanexus-upload-agent copy=no
+  unarchive: 
+    src: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-1.5.10-linux.tar.gz 
+    dest: /opt/dnanexus-upload-agent
+    copy: no
 
 - name: Move ua executable to un-versioned folder location for ease of reference
   shell: mv /opt/dnanexus-upload-agent/*/* /opt/dnanexus-upload-agent/
@@ -170,10 +176,10 @@
 
 # Set up CRON job for monitoring
 - name: set up CRON job to run every minute in debug mode with downstream applet
-  cron: >
-    name="DNAnexus monitor runs (debug)"
-    user="{{ item.0.username }}"
-    job="flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+  cron:
+    name: "DNAnexus monitor runs (debug)"
+    user: "{{ item.0.username }}"
+    job: "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories
@@ -183,11 +189,11 @@
 
 
 - name: set up CRON job to run every hour in deploy mode with downstream applet
-  cron: >
-    name="DNAnexus monitor runs (deploy)"
-    special_time=hourly
-    user="{{ item.0.username }}"
-    job="flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+  cron:
+    name: "DNAnexus monitor runs (deploy)"
+    special_time: hourly
+    user: "{{ item.0.username }}"
+    job: "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories
@@ -197,10 +203,10 @@
 
 # Clean up CRON job in alternate mode
 - name: delete deploy mode CRON job if debug mode set
-  cron: >
-    name="DNAnexus monitor runs (deploy)"
-    user="{{ item.username }}"
-    state=absent
+  cron:
+    name: "DNAnexus monitor runs (deploy)"
+    user: "{{ item.username }}"
+    state: absent
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
@@ -208,12 +214,11 @@
 
 
 - name: delete debug mode CRON job if deploy mode set
-  cron: >
-    name="DNAnexus monitor runs (debug)"
-    user="{{ item.username }}"
-    state=absent
+  cron:
+    name: "DNAnexus monitor runs (debug)"
+    user: "{{ item.username }}"
+    state: absent
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: mode == "deploy"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -176,11 +176,10 @@
 
 # Set up CRON job for monitoring
 - name: set up CRON job to run every minute in debug mode with downstream applet
-  cron:
-    name: "DNAnexus monitor runs (debug)"
-    user: "{{ item.0.username }}"
-    job: >
-      "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+  cron: >
+    name="DNAnexus monitor runs (debug)"
+    user="{{ item.0.username }}"
+    job="flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Install Dx-toolkit
 - name: Get DX tarball
-  unarchive: src=https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-14.04-amd64.tar.gz dest=/opt/ copy=no
+  unarchive: src=https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-14.04-amd64.tar.gz remote_src=yes dest=/opt/
 
 # http://stackoverflow.com/questions/22256884/not-possible-to-source-bashrc-with-ansible
 - name: check dx version
@@ -119,28 +119,31 @@
   when: item.n_upload_threads is defined
 
 - name: Change specification for downstream input
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^downstream_input:.*' line='downstream_input: \"{{ item.downstream_input }}\"'"
+  lineinfile: # escaping properly is important for this as downstream_input is/can be a JSON obj
+    dest: ~/dnanexus/config/monitor_runs.config
+    regexp: '^downstream_input:.*' 
+    line: "downstream_input: '{{ item.downstream_input }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.downstream_input is defined
 
 - name: Change specification for minimum upload size
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_size:.*' line='min_size: \'{{ item.min_size }}\''"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_size:.*' line='min_size: \"{{ item.min_size }}\"'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.min_size is defined
 
 - name: Change specification for minimum sync interval
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_interval:.*' line='min_interval: \'{{ item.min_interval }}\''"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_interval:.*' line='min_interval: \"{{ item.min_interval }}\"'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.min_interval is defined
 
 - name: Change specification for number of concurrent uploads
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_streaming_threads:.*' line='n_streaming_threads: \'{{ item.n_streaming_threads }}\''"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_streaming_threads:.*' line='n_streaming_threads: \"{{ item.n_streaming_threads }}\"'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,7 +179,8 @@
   cron:
     name: "DNAnexus monitor runs (debug)"
     user: "{{ item.0.username }}"
-    job: "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+    job: >
+      "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories
@@ -193,7 +194,8 @@
     name: "DNAnexus monitor runs (deploy)"
     special_time: hourly
     user: "{{ item.0.username }}"
-    job: "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
+    job: >
+      "flock -w 5 /var/lock/dnanexus_uploader.lock bash -ex -c 'source /opt/dx-toolkit/environment; PATH=/opt/dnanexus-upload-agent:$PATH; python /opt/dnanexus/scripts/monitor_runs.py -c ~/dnanexus/config/monitor_runs.config -p {{ upload_project }} -d {{ item.1 }} {{ \'-A\' if \'applet\' in item.0 else \'\' }} {{ item.0.applet if \'applet\' in item.0 else \'\'}} {{ \'-w\' if \'workflow\' in item.0 else \'\' }} {{ item.0.workflow if \'workflow\' in item.0 else \'\'}} {{ \'-s\' if \'script\' in item.0 else \'\' }} {{ item.0.script if \'script\' in item.0 else \'\'}} -v > ~/monitor.log 2>&1' > ~/dx-stream_cron.log 2>&1"
   with_subelements:
         - "{{ monitored_users }}"
         - monitored_directories


### PR DESCRIPTION
This updates a few more YAML values for the `lineinfile` tasks to use correct YAML escaping of quotes, including for the`downstream_inputs` parameter, which is or can be a JSON object and must be escaped carefully (broken out into separate YAML keys here to avoid risky nesting of quotes).