### PR TITLE
unarchive -> get_url; unarchive

### DIFF
--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -370,7 +370,7 @@ def _trigger_streaming_upload(folder, config):
 def trigger_streaming_upload(folders, config):
     """ Open a thread pool of size N_STREAMING_THREADS
     and trigger streaming upload for all unsynced and incomplete folders"""
-    pool = multiprocessing.Pool(processes=config["n_streaming_threads"])
+    pool = multiprocessing.Pool(processes=int(config["n_streaming_threads"]))
     for folder in folders:
         print "Adding folder {0} to pool".format(folder)
         pool.apply_async(_trigger_streaming_upload, args=(folder, config)).get()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     timeout: 600
 
 - name: unpack DX tarball
-  unarchive: src=/opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz dest=/opt/
+  unarchive: src=/opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz dest=/opt/ remote_src=yes
 
 - name: Remove DX tarball
   file:
@@ -38,7 +38,7 @@
     timeout: 600
 
 - name: unpack UA tarball
-  unarchive: src=/opt/dnanexus-upload-agent-current-linux.tar.gz dest=/opt/dnanexus-upload-agent
+  unarchive: src=/opt/dnanexus-upload-agent-current-linux.tar.gz dest=/opt/dnanexus-upload-agent remote_src=yes
 
 - name: Remove UA tarball
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,21 +122,21 @@
   when: item.run_length is defined
 
 - name: Change multiplier of run_times to wait
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_seq_intervals:.*' line='n_seq_intervals: \"{{ item.n_seq_intervals }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_seq_intervals:.*' line='n_seq_intervals: {{ item.n_seq_intervals }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.n_seq_intervals is defined
 
 - name: Change number of retries for incremental_upload
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_retries:.*' line='n_retries: \"{{ item.n_retries }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_retries:.*' line='n_retries: {{ item.n_retries }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.n_retries is defined
 
 - name: Change number of upload threads for UA
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_upload_threads:.*' line='n_upload_threads: \"{{ item.n_upload_threads }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_upload_threads:.*' line='n_upload_threads: {{ item.n_upload_threads }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
@@ -153,21 +153,21 @@
   when: item.downstream_input is defined
 
 - name: Change specification for minimum upload size
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_size:.*' line='min_size: \"{{ item.min_size }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_size:.*' line='min_size: {{ item.min_size }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.min_size is defined
 
 - name: Change specification for minimum sync interval
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_interval:.*' line='min_interval: \"{{ item.min_interval }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^min_interval:.*' line='min_interval: {{ item.min_interval }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
   when: item.min_interval is defined
 
 - name: Change specification for number of concurrent uploads
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_streaming_threads:.*' line='n_streaming_threads: \"{{ item.n_streaming_threads }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^n_streaming_threads:.*' line='n_streaming_threads: {{ item.n_streaming_threads }}'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,17 +3,17 @@
 - name: Get DX tarball
   get_url:
     url: https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
-    dest: /etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
+    dest: /opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
     mode: 0740
     timeout: 600
 
 - name: unpack DX tarball
-  unarchive: src=/etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz dest=/opt/
+  unarchive: src=/opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz dest=/opt/
 
 - name: Remove DX tarball
   file:
     state: absent
-    path: /etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
+    path: /opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
 
 # http://stackoverflow.com/questions/22256884/not-possible-to-source-bashrc-with-ansible
 - name: check dx version
@@ -33,17 +33,17 @@
 - name: Get UA tarball
   get_url:
     url: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-current-linux.tar.gz
-    dest: /etc/dnanexus-upload-agent-current-linux.tar.gz
+    dest: /opt/dnanexus-upload-agent-current-linux.tar.gz
     mode: 0740
     timeout: 600
 
 - name: unpack UA tarball
-  unarchive: src=/etc/dnanexus-upload-agent-current-linux.tar.gz dest=/opt/dnanexus-upload-agent
+  unarchive: src=/opt/dnanexus-upload-agent-current-linux.tar.gz dest=/opt/dnanexus-upload-agent
 
 - name: Remove UA tarball
   file:
     state: absent
-    path: /etc/dnanexus-upload-agent-current-linux.tar.gz
+    path: /opt/dnanexus-upload-agent-current-linux.tar.gz
 
 - name: Move ua executable to un-versioned folder location for ease of reference
   shell: mv /opt/dnanexus-upload-agent/*/* /opt/dnanexus-upload-agent/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,19 @@
 ---
 # Install Dx-toolkit
 - name: Get DX tarball
-  unarchive: 
-    src: https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-14.04-amd64.tar.gz 
-    remote_src: yes 
-    dest: /opt/
+  get_url:
+    url: https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
+    dest: /etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
+    mode: 0740
+    timeout: 600
+
+- name: unpack DX tarball
+  unarchive: src=/etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz dest=/opt/
+
+- name: Remove DX tarball
+  file:
+    state: absent
+    path: /etc/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
 
 # http://stackoverflow.com/questions/22256884/not-possible-to-source-bashrc-with-ansible
 - name: check dx version
@@ -21,11 +30,20 @@
 - name: Create folder to house upload agent
   file: path=/opt/dnanexus-upload-agent state=directory mode=0755
 
-- name: Download and unzip UA tarball
-  unarchive: 
-    src: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-1.5.10-linux.tar.gz 
-    dest: /opt/dnanexus-upload-agent
-    copy: no
+- name: Get UA tarball
+  get_url:
+    url: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-current-linux.tar.gz
+    dest: /etc/dnanexus-upload-agent-current-linux.tar.gz
+    mode: 0740
+    timeout: 600
+
+- name: unpack UA tarball
+  unarchive: src=/etc/dnanexus-upload-agent-current-linux.tar.gz dest=/opt/dnanexus-upload-agent
+
+- name: Remove UA tarball
+  file:
+    state: absent
+    path: /etc/dnanexus-upload-agent-current-linux.tar.gz
 
 - name: Move ua executable to un-versioned folder location for ease of reference
   shell: mv /opt/dnanexus-upload-agent/*/* /opt/dnanexus-upload-agent/


### PR DESCRIPTION
This migrates two ansible "unarchive" tasks to a series of get_url and unarchive tasks so a timeout can be set (the DNAnexus download times out fairly often). This appears to be the preferred pattern for downloading and extracting tarballs via ansible: ansible/ansible#32788