### PR TITLE
SCI-1619: use Upload Agent- version 1.5.30

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Download and unzip UA tarball
   unarchive: 
-    src: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-1.5.10-linux.tar.gz 
+    src: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-1.5.30-linux.tar.gz
     dest: /opt/dnanexus-upload-agent
     copy: no
 


### PR DESCRIPTION
This version of UA sets a timeout on uploads so it doesn't just hang when the client fails to receive an API response.

UA change here: dnanexus/dx-toolkit#512