### PR TITLE
added exclude_pattern attribute to ignore certain files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+dist: trusty
 language: python
 python: "2.7"
 sudo: yes

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Example Playbook
       - username: travis
         local_tar_directory: ~/new_location/upload/TMP
         local_log_directory: ~/another_location/upload/LOG
+        exclude_pattern: Analysis
         monitored_directories:
           - ~/runs
         applet: applet-Bq2Kkgj08FqbjV3J8xJ0K3gG

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Role Variables
   - `monitored_directories`: (Required)  Path to the local directory that should be monitored for RUN folders. Multiple directories can be listed. Suppose that the folder `20160101_M000001_0001_000000000-ABCDE` is the RUN directory, then the folder structure assumed is `{{monitored_dir}}/20160101_M000001_0001_000000000-ABCDE`
   - `local_tar_directory`: (Optional) Path to a local folder where tarballs of RUN directory is temporarily stored. User specified in `username` need to have **WRITE** access to this folder. There should be sufficient disk space to accomodate a RUN directory in this location. This overwrites the default found in `templates/monitor_run_config.template`.
   - `local_log_directory`: (Optional) Path to a local folder where logs of streaming upload is stored, persistently. User specified in `username` need to have **WRITE** access to this folder. User should not manually manipulate files found in this folder, as the streaming upload code make assumptions that the files in this folder are not manually manipulated. This overwites the default found in `templates/monitor_run_config.template`.
+  - `exclude_patterns`: (Optional) A list of regex patterns to exclude.  If 1 or more regex patterns are given, the files matching the pattern will be skipped (not tarred nor uploaded). The pattern will be matched against the full file path.
   - `delay_sample_sheet_upload`: (Optional) Specify whether the samplesheet for each run should be uploaded before (False) or after (True) the run data is uploaded. Useful if any manipulations are performed on the samplesheet during runtime. Default=False
   - `run_length`: (Optional) Expected duration of a sequencing run, corresponds to the -D paramter in incremental upload (For example, 24h). Acceptable suffix: s, m, h, d, w, M, y.
   - `n_seq_intervals`: (Optional) Number of intervals to wait for run to complete. If the sequencing run has not completed within `n_seq_intervals` * `run_length`, it will be deemed as aborted and the program will not attempt to upload it. Corresponds to the -I parameter in incremental upload.
@@ -59,7 +60,7 @@ Example Playbook
       - username: travis
         local_tar_directory: ~/new_location/upload/TMP
         local_log_directory: ~/another_location/upload/LOG
-        exclude_pattern: Analysis
+        exclude_patterns: Analysis
         monitored_directories:
           - ~/runs
         applet: applet-Bq2Kkgj08FqbjV3J8xJ0K3gG

--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -91,6 +91,8 @@ def parse_args():
             "will be overwritten programmatically, even if provided by user.")
     parser.add_argument("-S", "--samplesheet-delay", action="store_true",
             help="Delay samplesheet upload until run data is uploaded.")
+    parser.add_argument("-x", "--exclude-patterns", metavar='<regex>', nargs='*',
+            help="An optional list of regex patterns to exclude.") 
 
     # Mutually exclusive inputs for verbose loggin (UA) vs dxpy upload
     upload_debug_group = parser.add_mutually_exclusive_group(required=False)
@@ -261,7 +263,11 @@ def run_sync_dir(lane, args, finish=False):
         include_patterns = CONFIG_FILES
         include_patterns.append("s_" + lane_num + "_")
     # If upload_thumbnails is specified, upload thumbnails
-    exclude_patterns = []
+    if not args.exclude_patterns:
+        args.exclude_patterns = []
+    
+    exclude_patterns = args.exclude_patterns
+    
     if not args.upload_thumbnails:
         exclude_patterns.append("Images")
 

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -24,6 +24,7 @@ N_INTERVALS_TO_WAIT = 5
 CONFIG_DEFAULT = {
     "log_dir": "/opt/dnanexus/LOGS",
     "tmp_dir": "/opt/dnanexus/TMP",
+    "exclude": "",
     "min_age": 1000,
     "min_size": 1024,
     "min_interval": 1800,
@@ -346,6 +347,9 @@ def _trigger_streaming_upload(folder, config):
                "-u", config['n_upload_threads'],
                "--verbose"]
 
+    if config['exclude'] != '':
+        command += ["-x", config['exclude']]
+
     if 'applet' in config:
         command += ["-A", config['applet']]
 
@@ -368,7 +372,6 @@ def _trigger_streaming_upload(folder, config):
     try:
         inc_out = sub.check_output(command)
     except sub.CalledProcessError, e:
-        print "==ERROR== Incremental upload command {0} failed.\n "\
         "Error code {1}:{2}".format(e.cmd, e.returncode, e.output)
 
 def trigger_streaming_upload(folders, config):

--- a/files/monitor_runs.py
+++ b/files/monitor_runs.py
@@ -372,6 +372,7 @@ def _trigger_streaming_upload(folder, config):
     try:
         inc_out = sub.check_output(command)
     except sub.CalledProcessError, e:
+        print "==ERROR== Incremental upload command {0} failed.\n "\
         "Error code {1}:{2}".format(e.cmd, e.returncode, e.output)
 
 def trigger_streaming_upload(folders, config):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,11 +97,11 @@
   when: item.local_log_directory is defined
 
 - name: Change config file's local EXCLUDE pattern
-  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^exclude:.*' line='exclude: \"{{ item.exclude_pattern }}\"'"
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^exclude:.*' line='exclude: \"{{ item.exclude_patterns }}\"'"
   with_items: "{{ monitored_users }}"
   become: yes
   become_user: "{{ item.username }}"
-  when: item.exclude_pattern is defined
+  when: item.exclude_patterns is defined
 
 - name: Change anticipated run duration
   lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^run_length:.*' line='run_length: \"{{ item.run_length }}\"'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,13 @@
   become_user: "{{ item.username }}"
   when: item.local_log_directory is defined
 
+- name: Change config file's local EXCLUDE pattern
+  lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^exclude:.*' line='exclude: \"{{ item.exclude_pattern }}\"'"
+  with_items: "{{ monitored_users }}"
+  become: yes
+  become_user: "{{ item.username }}"
+  when: item.exclude_pattern is defined
+
 - name: Change anticipated run duration
   lineinfile: "dest=~/dnanexus/config/monitor_runs.config regexp='^run_length:.*' line='run_length: \"{{ item.run_length }}\"'"
   with_items: "{{ monitored_users }}"

--- a/templates/monitor_run_config.template
+++ b/templates/monitor_run_config.template
@@ -6,6 +6,10 @@ log_dir: '~/dnanexus/upload/LOGS'
 # Corresponds to -t parameter in incremental upload
 tmp_dir: '~/dnanexus/upload/TMP'
 
+# Exclude pattern for excluding files or directories
+# Corresponds to -x parameter in incremental upload and dx sync directory
+exclude: ''
+
 # Number of times to retry dx_sync_directory before quitting
 # default = 3; corresponds to -R parameter in incremental upload
 n_retries: 3


### PR DESCRIPTION
Added an extra parameter to dx-upload-play.yml to include an option to put an exclude pattern to exclude certain files from getting uploaded to DNAnexus.

The functionality already existed in dx_sync_directory.py (used to exclude 'Image'), and in incremental_upload.py.

Tested by including and not including the exclude_pattern attribute in dx-upload-play.yml.