### PR TITLE
Xvg 8585/donot reupload deleted completed runfolders

### DIFF
--- a/files/incremental_upload.py
+++ b/files/incremental_upload.py
@@ -349,7 +349,6 @@ def was_completed_run_uploaded(lane: dict, args: any) -> bool:
     if os.path.exists(lane["log_path"]):
         with open(lane["log_path"], "r+") as f:
             log = json.load(f)
-        if termination_file_exists(args.novaseq, args.run_dir):
             return log.get("was_completed_run_uploaded", False)
     return False
 

--- a/tests/e2e-docker/playbooks/XVG-8585.yml
+++ b/tests/e2e-docker/playbooks/XVG-8585.yml
@@ -1,0 +1,28 @@
+---
+- hosts: localhost
+  vars:
+    monitored_users:
+      - username: root
+        monitored_directories:
+          - /opt/dx-streaming-upload/tests/run-folder-a/
+        min_size: 1
+        max_size: 15
+        n_seq_intervals: 2
+        n_retries: 3
+        ua_progress: false
+        min_age: 1
+        # To ovwewrite Wait time interval before running the loop again in incremental_upload.py
+        # To avoid forever loop at this condition
+        # ###
+        # while not termination_file_exists(args.novaseq, args.run_dir):
+        #   ...
+        #   if diff < args.sync_interval:
+        #      logger.debug("Sleeping for %d seconds" % (int(args.sync_interval - diff)))
+        #      time.sleep(int(args.sync_interval - diff))
+        # ###
+        min_interval: 30  #  IF in deploy mode, then this value should be 1800
+        novaseq: true
+    mode: debug
+    upload_project: project-GjYYGb80YF3FyZ97xj58GPg8
+  roles:
+    - dx-streaming-upload

--- a/tests/e2e-docker/xvg-8585.dockerfile
+++ b/tests/e2e-docker/xvg-8585.dockerfile
@@ -1,0 +1,47 @@
+# Requirements: 
+#   When a completed run folder is deleted from DNAnexus platform, dx-streaming-upload will not reprocess the local existing Run-folder.
+# ----
+# Idea: Mark this information into the log file for tracking purpose
+# ----
+# This test include further manual action(s) to reproduce the behavior of the Requirements correctly
+# 1. Trigger the test
+# 2. Periodically check on the platform to see if any run folder has no files left to be tarred.
+# 3. After finding out one, run a command to inject the termination file to the run folder
+#    ```bash
+#       docker exec -i <container-id> /bin/bash -c 'echo "hello" > /path/to/file.xyz'
+#    ``` 
+# 4. Wait for the dx record of the run folder to close
+# 5. Manually delete the run folder from the platform
+# 6. Wait for 2-5 min to see if subsequent invocations reupload the run folder or NOT.
+# 7. To further verify it, lets do:
+#       Step 1: Exec to the container
+#           ```bash
+#               docker exec -it <container-id> bash
+#           ```
+#       Step 2: Delete crontab by doing:
+#           ```bash
+#               crontab -r
+#           ```
+#       Step 3: Retrigger the playbook
+#           ```bash
+#               ansible-playbook /opt/playbook.yml
+#           ```
+# 8. Wait for a while (~5mins) and comeback to check on the platform whether the run folder will be reuploaded for not.
+
+FROM dsu:latest
+
+COPY .build-context ./dx-streaming-upload
+
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output1.dat bs=12MB count=1
+
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180733_complete_novaseq/output1.dat bs=12MB count=1
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180733_complete_novaseq/output2.dat bs=12MB count=1
+
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180734_complete_novaseq/output1.dat bs=12MB count=1
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180734_complete_novaseq/output2.dat bs=12MB count=1
+RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180734_complete_novaseq/output3.dat bs=12MB count=1
+
+RUN rm -rf /opt/dx-streaming-upload/tests/run-folder-a/180732_inprogress_novaseq
+
+COPY ./playbooks/XVG-8585.yml /opt/playbook.yml
+ENTRYPOINT ["bash", "/opt/run.sh"]

--- a/tests/e2e-docker/xvg-8595.dockerfile
+++ b/tests/e2e-docker/xvg-8595.dockerfile
@@ -26,11 +26,6 @@ COPY .build-context ./dx-streaming-upload
 # Create file for run-folder-a/180733_inprogress_novaseq
 RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output1.dat bs=12MB count=1
 RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output2.dat bs=12MB count=1
-RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output3.dat bs=8MB count=1
-RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output4.dat bs=6MB count=1
-RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output5.dat bs=14MB count=1
-RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output6.dat bs=15MB count=1
-RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180731_complete_novaseq/output7.dat bs=16MB count=1
 # Create file for run-folder-a/180734_inprogress_novaseq
 RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180733_complete_novaseq/output1.dat bs=12MB count=1
 RUN dd if=/dev/zero of=/opt/dx-streaming-upload/tests/run-folder-a/180733_complete_novaseq/output2.dat bs=12MB count=1


### PR DESCRIPTION
# What have done:
- Add key `was_completed_folder_uploaded` to the run log file and set to True right after the Sentinel Record closes.
- Avoid uploading any file or creating the DXRecord when the Run Log File exists and it has key `was_completed_folder_uploaded = True`
- Add e2e docker test

# Test Case description:

Requirements: When a completed run folder is deleted from DNAnexus platform, dx-streaming-upload will not reprocess the local existing Run-folder.
----
Idea: Mark this information into the log file for tracking purpose

This test include further manual action(s) to reproduce the behavior of the Requirements correctly

1. Trigger the test
2. Periodically check on the platform to see if any run folder has no files left to be tarred.
3. After finding out one, run a command to inject the termination file to the run folder

   ```bash
      docker exec -i <container-id> /bin/bash -c 'echo "hello" > /path/to/file.xyz'
   ``` 
4. Wait for the dx record of the run folder to close
5. Manually delete the run folder from the platform
6. Wait for 2-5 min to see if subsequent invocations reupload the run folder or NOT.
7. To further verify it, lets do:
        Step 1: Exec to the container
            ```bash
                docker exec -it <container-id> bash
            ```
        Step 2: Delete crontab by doing:
            ```bash
                crontab -r
            ```
        Step 3: Retrigger the playbook
            ```bash
                ansible-playbook /opt/playbook.yml
            ```
8. Wait for a while (~5mins) and comeback to check on the platform whether the run folder will be reuploaded for not.